### PR TITLE
Added new model: Multilaser PRO RE708

### DIFF
--- a/src/main/java/com/krtv/router/domain/RouterModel.java
+++ b/src/main/java/com/krtv/router/domain/RouterModel.java
@@ -12,6 +12,7 @@ package com.krtv.router.domain;
 public enum RouterModel {
     ZXHNH198A,
     GWR1200AC,
+    MULTILASER_PRO_RE708,
     GWR300N;
 
     public static RouterModel fromString(String model) {

--- a/src/main/java/com/krtv/router/infra/selenium/mprore708/FieldsMultilaserProRe708.java
+++ b/src/main/java/com/krtv/router/infra/selenium/mprore708/FieldsMultilaserProRe708.java
@@ -1,0 +1,38 @@
+package com.krtv.router.infra.selenium.mprore708;
+
+import com.krtv.router.infra.selenium.service.fields.common.FieldType;
+
+public enum FieldsMultilaserProRe708 {
+    PASSWORD("password", FieldType.INPUT_TEXT_BY_NAME),
+    ON_OFF("autoexec", FieldType.RADIO_BUTTON_BY_NAME),
+    URL("url", FieldType.INPUT_TEXT_BY_NAME),
+    USERNAME("username", FieldType.INPUT_TEXT_BY_NAME),
+    SAVE_AND_APPLY("save_apply", FieldType.BUTTON_CLICK_BY_NAME);
+
+    private final String id;
+    private final FieldType type;
+
+    FieldsMultilaserProRe708(String id, FieldType type) {
+        this.id = id;
+        this.type = type;
+    }
+
+    public static FieldsMultilaserProRe708 fromString(String model) {
+        if (model != null) {
+            for (FieldsMultilaserProRe708 fieldsGwr1200ac : FieldsMultilaserProRe708.values()) {
+                if (fieldsGwr1200ac.name().equals(model))
+                    return fieldsGwr1200ac;
+            }
+        }
+
+        return null;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public FieldType getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/krtv/router/infra/selenium/mprore708/LoginPageMultilaserProRe708.java
+++ b/src/main/java/com/krtv/router/infra/selenium/mprore708/LoginPageMultilaserProRe708.java
@@ -1,0 +1,29 @@
+package com.krtv.router.infra.selenium.mprore708;
+
+import com.krtv.router.infra.selenium.gwr300n.TR069PageGwr300n;
+import com.krtv.router.infra.selenium.service.router.PageObject;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class LoginPageMultilaserProRe708 extends PageObject  {
+    private final TR069PageMultilaserProRe708 tr069Page;
+
+    public TR069PageMultilaserProRe708 submit(String urlBase, String username, String password) {
+        this.start(null);
+        this.setUrlBaseWithCredentials(urlBase, username, password);
+
+        log.info("Trying to login: {}", this.url);
+        log.info("URL with credentials: {}", this.urlBaseWithCredentials);
+
+        this.browser.get(this.urlBaseWithCredentials);
+
+        tr069Page.load(this.browser, this.url, this.urlBaseWithCredentials);
+        return tr069Page;
+    }
+
+
+}

--- a/src/main/java/com/krtv/router/infra/selenium/mprore708/TR069PageMultilaserProRe708.java
+++ b/src/main/java/com/krtv/router/infra/selenium/mprore708/TR069PageMultilaserProRe708.java
@@ -1,0 +1,53 @@
+package com.krtv.router.infra.selenium.mprore708;
+
+import com.krtv.router.infra.selenium.service.fields.ButtonClickService;
+import com.krtv.router.infra.selenium.service.fields.InputDataService;
+import com.krtv.router.infra.selenium.service.fields.UpdateFieldStrategyFactory;
+import com.krtv.router.infra.selenium.service.router.PageObject;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.openqa.selenium.WebDriver;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class TR069PageMultilaserProRe708 extends PageObject {
+
+    private final UpdateFieldStrategyFactory updateFieldStrategyFactory;
+
+    public void load(WebDriver browser, String url, String urlWithCredentials) {
+        this.start(browser);
+        this.url = url;
+        this.urlBaseWithCredentials = urlWithCredentials;
+        log.info("calling tr069 page, {}", this.url + "tr069config.htm");
+        this.browser.navigate().to(this.url + "tr069config.htm");
+    }
+
+    public void execute(Map<String, String> data) throws Exception {
+        try {
+            data.forEach(this::executeField);
+            FieldsMultilaserProRe708 button = FieldsMultilaserProRe708.SAVE_AND_APPLY;
+            ButtonClickService buttonClickService = (ButtonClickService) updateFieldStrategyFactory.findService(button.getType());
+            buttonClickService.execute(browser, button.getId());
+        } catch (Exception ex) {
+            log.error("Error to update router.");
+            throw ex;
+        }
+    }
+
+    private void executeField(String field, String value) {
+        try {
+            log.info("field: {}, new value: {}", FieldsMultilaserProRe708.fromString(field).getId(), value);
+            FieldsMultilaserProRe708 current = FieldsMultilaserProRe708.fromString(field);
+
+            InputDataService inputDataService = (InputDataService) updateFieldStrategyFactory.findService(current.getType());
+            inputDataService.execute(browser, current.getId(), value);
+        } catch (Exception ex) {
+            log.error("Error to update field({}).", field);
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/com/krtv/router/infra/selenium/mprore708/UpdateRouterServiceMultilaserProRe708.java
+++ b/src/main/java/com/krtv/router/infra/selenium/mprore708/UpdateRouterServiceMultilaserProRe708.java
@@ -1,0 +1,47 @@
+package com.krtv.router.infra.selenium.mprore708;
+
+import com.krtv.router.domain.RouterModel;
+import com.krtv.router.infra.scheduled.UpdateRouterDto;
+import com.krtv.router.infra.selenium.gwr1200ac.LoginPageGwr1200ac;
+import com.krtv.router.infra.selenium.gwr1200ac.TR069PageGwr1200ac;
+import com.krtv.router.infra.selenium.service.router.UpdateRouterService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class UpdateRouterServiceMultilaserProRe708 implements UpdateRouterService {
+    private final LoginPageMultilaserProRe708 login;
+
+    @Override
+    public void execute(UpdateRouterDto updateRouterDto) throws Exception {
+        log.info("Service for update router is called {}", updateRouterDto.getModel());
+
+        try {
+            TR069PageMultilaserProRe708 tr069Page = this.login.submit(updateRouterDto.getUrl(),
+                    updateRouterDto.getUsername(),
+                    updateRouterDto.getPassword());
+
+            Thread.sleep(5000);
+
+            tr069Page.execute(updateRouterDto.getData());
+
+            Thread.sleep(5000);
+        } catch (Exception ex) {
+            log.error(ex);
+            log.error("An error occurred during the updating process.");
+            throw ex;
+        } finally {
+            this.login.close();
+        }
+
+    }
+
+    @Override
+    public RouterModel getRouterModel() {
+        return RouterModel.MULTILASER_PRO_RE708;
+    }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ config:
   maximumNumberTries: 5
   pathWebDriver: /home/kelvin/Documents/Pessoal/KRTV/drivers/chromedriver
   timeout: 60
-  enableHeadless: true
+  enableHeadless: false
   sleepStep: 3000
 
 spring:


### PR DESCRIPTION
Now the software can perform bulk updates on **Multilaser PRO RE708** routers.

The accepted fields are: 

1. ON_OFF (to enable TR069)
2. URL (to define the ACS URL)
3. USERNAME (to set the username for TR069)
4. PASSWORD (to set the password for TR069)

Example of request to create a task for this model:

`{
  "routers": [
    {
      "ip": "router ip",
      "port": 8080 // router port,
      "protocol": "HTTP",
      "contextPath": "",
      "model": "MULTILASER_PRO_RE708",
      "username": "user name to access the router configuration",
      "password": "password to acess the router configuration",
      "data": {
        "ON_OFF": "0 - disable TR069 | 1 - enable TR069",
        "URL": "http://url-acs",
        "USERNAME": "username for TR069",
        "PASSWORD": "password for TR069"
      }
    }
  ]
}`
